### PR TITLE
Added roach.int with fixed-precision IntTypes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,13 @@ Currently Cockroach exports the following methods:
   - md5
   - sha1, sha224, sha256, sha384, sha512
 
+* Int-types
+
+  - fixed-size int/uint types
+
 * String
 
-  - int/uint 8/16/32/64 serialization
+  - int/uint 8/16/32/64 (de)serialization
   - bigint serialization
   - ipv4 parsing
   - null/pkcs7 (un)padding
@@ -114,10 +118,10 @@ String
 
 .. code-block::
 
-    >>> from roach import int8, uint32, ipv4, pad
-    >>> int8("\xff")
+    >>> from roach import Int8, UInt32, ipv4, pad
+    >>> Int8.unpack("\xff")
     -1
-    >>> uint32("\xe8\x03\x00\x009\x05\x00\x00)#\x00\x00")
+    >>> (UInt32 * 3).unpack("\xe8\x03\x00\x009\x05\x00\x00)#\x00\x00")
     (1000, 1337, 9001)
     >>> ipv4("\x7f\x00\x00\x01")
     '127.0.0.1'
@@ -195,12 +199,12 @@ Structure
 
 .. code-block::
 
-    >>> from roach import Structure, uint8, uint32
+    >>> from roach import Structure, CHAR, DWORD
     >>> class A(Structure):
     ...   _fields_ = [
-    ...     ("a", uint8),
-    ...     ("b", uint8 * 3),
-    ...     ("c", uint32 * 2),
+    ...     ("a", CHAR),
+    ...     ("b", CHAR * 3),
+    ...     ("c", DWORD * 2),
     ...     ("d", 8),
     ...   ]
     ...

--- a/roach/__init__.py
+++ b/roach/__init__.py
@@ -25,6 +25,14 @@ from roach.short import (
 )
 
 from roach.string.bin import (
-    int8, uint8, int16, uint16, int32, uint32, int64, uint64,
+    uint8, uint16, uint32, uint64,
+    u8, u16, u32, u64,
+    p8, p16, p32, p64,
     bigint, pack, unpack
+)
+
+from roach.ints import (
+    QWORD, DWORD, WORD, BYTE, CHAR,
+    UInt64, UInt32, UInt16, UInt8,
+    Int64, Int32, Int16, Int8
 )

--- a/roach/crypto/winhdr.py
+++ b/roach/crypto/winhdr.py
@@ -2,16 +2,16 @@
 # This file is part of Roach - https://github.com/jbremer/roach.
 # See the file 'docs/LICENSE.txt' for copying permission.
 
-from roach.string.bin import uint8, uint16, uint32
+from roach.ints import UInt8, UInt16, UInt32
 from roach.structure import Structure
 
 class BLOBHEADER(Structure):
     _pack_ = 1
     _fields_ = [
-        ("bType", uint8),
-        ("bVersion", uint8),
-        ("wReserved", uint16),
-        ("aiKeyAlg", uint32),
+        ("bType", UInt8),
+        ("bVersion", UInt8),
+        ("wReserved", UInt16),
+        ("aiKeyAlg", UInt32),
     ]
 
 class BaseBlob(object):

--- a/roach/ints.py
+++ b/roach/ints.py
@@ -1,0 +1,178 @@
+from .bits import rol
+from struct import pack, unpack, unpack_from, error
+
+
+class IntTypeBase(object):
+    """
+    Base class representing all IntType instances
+    """
+    pass
+
+
+class MultipliedIntTypeBase(IntTypeBase):
+    """
+    Base class representing all MultipliedIntType instances
+    """
+    int_type = None
+    mul = 0
+
+
+class MetaIntType(type):
+    """
+    Metaclass for IntType classes.
+    Provides ctypes-like behavior e.g. (QWORD*8).unpack(...) returns tuple of 8 QWORDs
+    """
+    @property
+    def mask(cls):
+        """
+        Mask for potentially overflowing operations
+        """
+        return (2 ** cls.bits) - 1
+
+    @property
+    def invert_mask(cls):
+        """
+        Mask for sign bit
+        """
+        return (2 ** cls.bits) >> 1
+
+    def __mul__(cls, multiplier):
+        class MultipliedIntTypeClass(MultipliedIntTypeBase):
+            int_type = cls
+            mul = multiplier
+
+            @staticmethod
+            def unpack(other, offset=0):
+                """
+                Unpacks multiple values from provided buffer
+                :param other: Buffer object containing value to unpack
+                :param offset: Buffer offset
+                :return: tuple of IntType instances or None if there are not enough data to unpack
+                """
+                fmt = cls.fmt + cls.fmt[-1] * (multiplier - 1)
+                try:
+                    ret = unpack_from(fmt, other, offset=offset)
+                except error:
+                    return None
+                return tuple(map(cls, ret))
+
+        MultipliedIntTypeClass.__name__ = "Multiplied" + cls.__name__
+        return MultipliedIntTypeClass
+
+
+class IntType(long, IntTypeBase):
+    """
+    Fixed-size variant of long type with C-style operators and casting
+    Supports ctypes-like multiplication for unpacking tuple of values
+    """
+
+    bits = 64
+    signed = False
+    fmt = "<Q"
+
+    __metaclass__ = MetaIntType
+
+    def __new__(cls, value):
+        value = long(value) & cls.mask
+        if cls.signed:
+            value |= -(value & cls.invert_mask)
+        return long.__new__(cls, value)
+
+    def __add__(self, other):
+        res = super(IntType, self).__add__(other)
+        return self.__class__(res)
+
+    def __sub__(self, other):
+        res = super(IntType, self).__sub__(other)
+        return self.__class__(res)
+
+    def __mul__(self, other):
+        res = super(IntType, self).__mul__(other)
+        return self.__class__(res)
+
+    def __div__(self, other):
+        res = super(IntType, self).__div__(other)
+        return self.__class__(res)
+
+    def __truediv__(self, other):
+        res = super(IntType, self).__truediv__(other)
+        return self.__class__(res)
+
+    def __floordiv__(self, other):
+        res = super(IntType, self).__floordiv__(other)
+        return self.__class__(res)
+
+    def __and__(self, other):
+        res = super(IntType, self).__and__(other)
+        return self.__class__(res)
+
+    def __xor__(self, other):
+        res = super(IntType, self).__xor__(other)
+        return self.__class__(res)
+
+    def __or__(self, other):
+        res = super(IntType, self).__or__(other)
+        return self.__class__(res)
+
+    def __lshift__(self, other):
+        res = super(IntType, self).__lshift__(other)
+        return self.__class__(res)
+
+    def __pos__(self):
+        res = super(IntType, self).__pos__()
+        return self.__class__(res)
+
+    def __abs__(self):
+        res = super(IntType, self).__abs__()
+        return self.__class__(res)
+
+    def __rshift__(self, other):
+        res = long.__rshift__(long(self) & self.__class__.mask, other)
+        return self.__class__(res)
+
+    def __neg__(self):
+        res = (long(self) ^ self.__class__.mask) + 1
+        return self.__class__(res)
+
+    def __invert__(self):
+        res = long(self) ^ self.__class__.mask
+        return self.__class__(res)
+
+    def rol(self, other):
+        return self.__class__(rol(long(self), other, bits=self.bits))
+
+    def ror(self, other):
+        return self.rol(self.bits - other)
+
+    def pack(self):
+        return pack(self.fmt, long(self))
+
+    @classmethod
+    def unpack(cls, other, offset=0):
+        """
+        Unpacks single value from provided buffer
+        :param other: Buffer object containing value to unpack
+        :param offset: Buffer offset
+        :return: IntType instance or None if there are not enough data to unpack
+        """
+        try:
+            ret = unpack_from(cls.fmt, other, offset=offset)
+        except error:
+            return None
+        return cls(ret[0])
+
+
+# Unsigned types
+
+QWORD = UInt64 = type("UInt64", (IntType,), dict(bits=64, signed=False, fmt="<Q"))
+DWORD = UInt32 = type("UInt32", (IntType,), dict(bits=32, signed=False, fmt="<I"))
+WORD = UInt16 = type("UInt16", (IntType,), dict(bits=16, signed=False, fmt="<H"))
+CHAR = BYTE = UInt8 = type("UInt8", (IntType,), dict(bits=8, signed=False, fmt="<B"))
+
+# Signed types
+
+Int64 = type("Int64", (IntType,), dict(bits=64, signed=True, fmt="<q"))
+Int32 = type("Int32", (IntType,), dict(bits=32, signed=True, fmt="<i"))
+Int16 = type("Int16", (IntType,), dict(bits=16, signed=True, fmt="<h"))
+Int8 = type("Int8", (IntType,), dict(bits=8, signed=True, fmt="<b"))
+

--- a/roach/string/bin.py
+++ b/roach/string/bin.py
@@ -5,70 +5,8 @@
 import struct
 
 from roach.string.ops import Padding, hex, unhex
+from roach.ints import UInt8, UInt16, UInt32, UInt64
 
-class IntWorker(object):
-    fmt = None
-    size = None
-
-    def __init__(self, mul=None):
-        self.mul = mul
-
-    def __call__(self, value):
-        if isinstance(value, (int, long)):
-            return struct.pack(self.fmt, value)
-
-        count = len(value) / self.size
-        # TODO Should we return something else?
-        if not count:
-            return
-
-        ret = struct.unpack(self.fmt*count, value)
-        return ret[0] if count == 1 else ret
-
-    def __mul__(self, other):
-        """Helper method for roach.structure.Structure."""
-        return self.__class__(other)
-
-class Int8(IntWorker):
-    fmt = "b"
-    size = 1
-
-class UInt8(IntWorker):
-    fmt = "B"
-    size = 1
-
-class Int16(IntWorker):
-    fmt = "h"
-    size = 2
-
-class UInt16(IntWorker):
-    fmt = "H"
-    size = 2
-
-class Int32(IntWorker):
-    fmt = "i"
-    size = 4
-
-class UInt32(IntWorker):
-    fmt = "I"
-    size = 4
-
-class Int64(IntWorker):
-    fmt = "q"
-    size = 8
-
-class UInt64(IntWorker):
-    fmt = "Q"
-    size = 8
-
-int8 = Int8()
-uint8 = UInt8()
-int16 = Int16()
-uint16 = UInt16()
-int32 = Int32()
-uint32 = UInt32()
-int64 = Int64()
-uint64 = UInt64()
 
 def bigint(s, bitsize):
     if isinstance(s, (int, long)):
@@ -79,6 +17,18 @@ def bigint(s, bitsize):
 
     return int(hex(s[:bitsize / 8][::-1]), 16)
 
-# TODO Do we need any love on top of this?
+
+# Shortcuts for mostly used unpack methods
+uint64 = u64 = UInt64.unpack
+uint32 = u32 = UInt32.unpack
+uint16 = u16 = UInt16.unpack
+uint8 = u8 = UInt8.unpack
+
+# Shortcuts for mostly used pack methods
+p64 = lambda v: UInt64(v).pack()
+p32 = lambda v: UInt32(v).pack()
+p16 = lambda v: UInt16(v).pack()
+p8 = lambda v: UInt8(v).pack()
+
 unpack = struct.unpack
 pack = struct.pack

--- a/roach/string/inet.py
+++ b/roach/string/inet.py
@@ -5,12 +5,13 @@
 import re
 import socket
 
-from roach.string.bin import uint32
+from roach.string.bin import p32
 
 ipv4_regex = re.compile(
     "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}"
     "([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
 )
+
 
 def ipv4(s):
     if isinstance(s, basestring):
@@ -19,4 +20,4 @@ def ipv4(s):
         if re.match(ipv4_regex, s):
             return s
     if isinstance(s, (int, long)):
-        return socket.inet_ntoa(uint32(s)[::-1])
+        return socket.inet_ntoa(p32(s)[::-1])

--- a/roach/structure.py
+++ b/roach/structure.py
@@ -4,8 +4,8 @@
 
 import ctypes
 
-from roach.string.bin import (
-    IntWorker, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64
+from roach.ints import (
+    IntTypeBase, MultipliedIntTypeBase, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64
 )
 
 mapping = {
@@ -19,6 +19,7 @@ mapping = {
     UInt64: ctypes.c_ulonglong,
 }
 
+
 class Structure(object):
     # TODO Default value in Python, should we change this to 1?
     _pack_ = 0
@@ -27,13 +28,13 @@ class Structure(object):
     def __init__(self):
         self.subfields, fields = {}, []
         for field, type_ in self._fields_:
-            if isinstance(type_, IntWorker):
-                if type_.mul:
-                    type_ = mapping[type_.__class__] * type_.mul
-                else:
-                    type_ = mapping[type_.__class__]
-            elif isinstance(type_, (int, long)):
+            if isinstance(type_, (int, long)):
                 type_ = ctypes.c_char * type_
+            elif issubclass(type_, IntTypeBase):
+                if issubclass(type_, MultipliedIntTypeBase):
+                    type_ = mapping[type_.int_type] * type_.mul
+                else:
+                    type_ = mapping[type_]
             elif issubclass(type_, Structure):
                 # Keep track, likely for Python GC purposes.
                 self.subfields[field] = type_()

--- a/tests/test_bits.py
+++ b/tests/test_bits.py
@@ -10,3 +10,11 @@ def test_rotate():
 
     assert ror(0b11100000, 3, 8) == 0b00011100
     assert ror(0b11100011, 1, 8) == 0b11110001
+
+
+def test_overrotate():
+    assert rol(0b11100000, 19, 8) == 0b00000111
+    assert rol(0b11100011, 17, 8) == 0b11000111
+
+    assert ror(0b11100000, 11, 8) == 0b00011100
+    assert ror(0b11100011, 10, 8) == 0b11111000

--- a/tests/test_ints.py
+++ b/tests/test_ints.py
@@ -1,0 +1,119 @@
+from roach import (
+    Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    u8, u16, u32, u64,
+    p8, p16, p32, p64
+)
+
+
+def test_int_like():
+    """
+    All IntTypes should behave like built-in int (long)
+    """
+    assert Int8("33") == 33
+    assert Int8("-33") == -33
+    assert UInt8("-2") == 254
+    assert Int8(33) == 33
+    assert Int8(1.5) == 1
+    assert not Int8(0)
+    assert Int8(-1) <= 0
+
+    assert not u8("\x00")
+    assert sorted([u16("\x00\x10"), u16("\x10\x00")]) == [0x10, 0x1000]
+
+    assert [Int8(0x7F), Int16(0x7F), Int32(0x7F), Int64(0x7F),
+            UInt8(0x7F), UInt16(0x7F), UInt32(0x7F), UInt64(0x7F)] == [0x7F]*8
+
+
+def test_unsigned():
+    assert UInt8(255) + 10 + 256 == 9
+    n = UInt8(-1)
+    n -= 1
+    assert n == 254
+
+    assert UInt16(0xF0F0) << 8 == 0xF000
+    assert UInt16(0x4000) << 1 == 0x8000
+    assert UInt64(0xFFFFFFFF) << 32 == 0xFFFFFFFF00000000
+    assert UInt64(0xFFFFFFFF) << 48 == 0xFFFF000000000000
+    assert UInt64(0xFFFFFFFF) >> 32 == 0
+    assert UInt32(0xFFFFFFFF) << 32 == 0
+
+    assert UInt8(-1) == 255
+    assert UInt16(-1) == 65535
+    assert UInt16(-1) * -1 == 1
+    assert UInt16(-4) / 2 == UInt16(-4) >> 1
+    assert UInt32(-65535) > UInt32(65535)
+
+    assert UInt32(0x4444FFFF) << 16 | 0x8080 == 0xFFFF8080
+
+    assert UInt8(UInt32(0xF0F0F0F0)) == 0xF0
+
+    assert 255 + UInt8(1) == 256
+    assert UInt8(255) + 1 == 0
+
+    assert -UInt8(-1) == 1
+    assert -UInt8(1) == UInt8(-1)
+
+    assert ~UInt8(0xFF) == 0
+
+    assert abs(UInt8(-1)) == UInt8(-1)
+
+    assert p64(0x12345678) == "\x78\x56\x34\x12\x00\x00\x00\x00"
+    assert p32(0x12345678) == "\x78\x56\x34\x12"
+    assert p8(0x12345678) == "\x78"
+
+    assert p16(-1) == "\xFF\xFF"
+    assert p16(-32768) == "\x00\x80"
+
+    assert u32("\x78\x56\x34\x12") == 0x12345678
+
+    assert u64("\x78\x56\x34\x12") is None
+
+
+def test_signed():
+    assert Int8(255) + 10 + 256 == 9
+    assert Int8(255) - 10 == -11
+    n = Int8(-1)
+    n += 1
+    assert n == 0
+
+    assert Int16(0xF0F0) << 8 == -0x1000
+    assert Int16(0x4000) << 1 == -0x8000
+
+    assert Int8(-1) == -1
+    assert Int16(-1) * -1 == 1
+    assert Int16(-4) / 2 == -2
+    assert Int32(-65535) < UInt32(65535)
+
+    assert Int8(-128) - 1 == 127
+
+    assert -Int8(-1) == 1
+    assert -Int8(1) == -1
+
+    assert abs(Int8(-1)) == Int8(1)
+
+    assert ~Int8(0xFF) == 0
+
+
+def test_rotate():
+    assert UInt8(0b11100000).rol(3) == 0b00000111
+    assert UInt8(0b11100011).rol(1) == 0b11000111
+
+    assert UInt8(0b11100000).ror(3) == 0b00011100
+    assert UInt8(0b11100011).ror(1) == 0b11110001
+
+
+def test_multi_unpack():
+    assert (UInt32 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") == (0x44332211, 0xffffffff, 0)
+    assert (Int32 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") == (0x44332211, -1, 0)
+
+    assert (UInt16 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") == (0x2211, 0x4433, 0xffff)
+    assert (Int16 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") == (0x2211, 0x4433, -1)
+
+    assert (UInt64 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") is None
+    assert (Int64 * 3).unpack("\x11\x22\x33\x44\xff\xff\xff\xff\x00\x00\x00\x00") is None
+
+
+def test_unpack_from():
+    assert UInt32.unpack("\xAA\xAA\xF0\x0F\xF0\x0B\xAA", offset=2) == u32("\xF0\x0F\xF0\x0B")
+    assert UInt32.unpack("\xAA\xAA\xF0\x0F\xF0\x0B", offset=2) == u32("\xF0\x0F\xF0\x0B")
+    assert UInt32.unpack("\xAA\xAA\xF0\x0F\xF0", offset=2) is None

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -3,7 +3,8 @@
 # See the file 'docs/LICENSE.txt' for copying permission.
 
 from roach import (
-    int8, uint8, int16, uint16, int32, uint32, int64, uint64, bigint,
+    uint8, uint16, uint32, uint64, bigint,
+    p8, p16, p32, p64,
     asciiz, pad, unpad, ipv4, pack, unpack, hex, unhex, base64, uleb128
 )
 
@@ -56,70 +57,38 @@ def test_ipv4():
 
     assert ipv4(0x7f000001) == "127.0.0.1"
 
+
 def test_bin():
-    assert int8("") is None
-    assert int8("A") == 0x41
-    assert int8("\xff") == -1
     assert uint8("") is None
     assert uint8("B") == 0x42
     assert uint8("\xff") == 0xff
 
-    assert int8("A\xffB") == (0x41, -1, 0x42)
-    assert uint8("A\xffB") == (0x41, 0xff, 0x42)
-
-    assert int16("A") is None
-    assert int16("AB") == 0x4241
-    assert int16("\xff\xff") == -1
+    assert uint16("A") is None
     assert uint16("AB") == 0x4241
     assert uint16("\xff\xff") == 0xffff
 
-    assert int16("AB\xff\xffEF") == (0x4241, -1, 0x4645)
-    assert uint16("AB\xff\xffEF") == (0x4241, 0xffff, 0x4645)
-
-    assert int32("ABC") is None
-    assert int32("ABCD") == 0x44434241
-    assert int32("\xff\xff\xff\xff") == -1
+    assert uint32("ABC") is None
     assert uint32("ABCD") == 0x44434241
     assert uint32("\xff\xff\xff\xff") == 0xffffffff
 
-    assert int32("ABCD\xff\xff\xff\xffEFGH") == (0x44434241, -1, 0x48474645)
-    assert uint32("ABCD\xff\xff\xff\xffEFGH") == (
-        0x44434241, 0xffffffff, 0x48474645
-    )
-
-    assert int64("ABCDEFG") is None
-    assert int64("ABCDEFGH") == 0x4847464544434241
-    assert int64("\xff\xff\xff\xff\xff\xff\xff\xff") == -1
+    assert uint64("ABCDEFG") is None
     assert uint64("HGFEDCBA") == 0x4142434445464748
     assert uint64("\xff\xff\xff\xff\xff\xff\xff\xff") == 0xffffffffffffffff
 
-    assert int64("A"*8 + "\xff"*8 + "B"*8) == (
-        0x4141414141414141, -1, 0x4242424242424242
-    )
-    assert uint64("A"*8 + "\xff"*8 + "B"*8) == (
-        0x4141414141414141, 0xffffffffffffffff, 0x4242424242424242
-    )
 
 def test_bin_reverse():
-    assert int8(0x12) == "\x12"
-    assert int8(-1) == "\xff"
-    assert uint8(0x34) == "\x34"
-    assert uint8(0xff) == "\xff"
+    assert p8(0x12) == "\x12"
+    assert p8(0x34) == "\x34"
+    assert p8(0xff) == "\xff"
 
-    assert int16(0x1234) == "\x34\x12"
-    assert int16(-1) == "\xff\xff"
-    assert uint16(0x5678) == "\x78\x56"
-    assert uint16(0xffff) == "\xff\xff"
+    assert p16(0x5678) == "\x78\x56"
+    assert p16(0xffff) == "\xff\xff"
 
-    assert int32(0x12345678) == "\x78\x56\x34\x12"
-    assert int32(-1) == "\xff\xff\xff\xff"
-    assert uint32(0x87654321) == "\x21\x43\x65\x87"
-    assert uint32(0xffffffff) == "\xff\xff\xff\xff"
+    assert p32(0x87654321) == "\x21\x43\x65\x87"
+    assert p32(0xffffffff) == "\xff\xff\xff\xff"
 
-    assert int64(0x1122334455667788) == "\x88\x77\x66\x55\x44\x33\x22\x11"
-    assert int64(-1) == "\xff\xff\xff\xff\xff\xff\xff\xff"
-    assert uint64(0x8877665544332211) == "\x11\x22\x33\x44\x55\x66\x77\x88"
-    assert uint64(0xffffffffffffffff) == "\xff\xff\xff\xff\xff\xff\xff\xff"
+    assert p64(0x8877665544332211) == "\x11\x22\x33\x44\x55\x66\x77\x88"
+    assert p64(0xffffffffffffffff) == "\xff\xff\xff\xff\xff\xff\xff\xff"
 
 def test_bigint():
     assert bigint("ABCD", 40) is None

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,7 +3,7 @@
 # See the file 'docs/LICENSE.txt' for copying permission.
 
 from roach import (
-    Structure, int8, uint8, int16, uint16, int32, uint32, int64, uint64
+    Structure, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64
 )
 
 def test_structure():
@@ -93,14 +93,14 @@ def test_structure():
 def test_int_wrappers():
     class I1(Structure):
         _fields_ = [
-            ("a", int8),
-            ("b", uint8),
-            ("c", int16),
-            ("d", uint16),
-            ("e", int32),
-            ("f", uint32),
-            ("g", int64),
-            ("h", uint64),
+            ("a", Int8),
+            ("b", UInt8),
+            ("c", Int16),
+            ("d", UInt16),
+            ("e", Int32),
+            ("f", UInt32),
+            ("g", Int64),
+            ("h", UInt64),
         ]
 
     assert I1.sizeof() == 32
@@ -127,16 +127,16 @@ def test_int_wrappers():
     class I2(Structure):
         _fields_ = [
             ("i1", I1),
-            ("a", uint32),
-            ("b", int64),
+            ("a", UInt32),
+            ("b", Int64),
         ]
 
     class I3(Structure):
         _pack_ = 1
         _fields_ = [
             ("i1", I1),
-            ("a", uint32),
-            ("b", int64),
+            ("a", UInt32),
+            ("b", Int64),
         ]
 
     assert I2.sizeof() == 48
@@ -163,8 +163,8 @@ def test_int_wrappers():
 class test_multiply():
     class M(Structure):
         _fields_ = [
-            ("a", uint8 * 8),
-            ("b", uint32 * 4),
+            ("a", UInt8 * 8),
+            ("b", UInt32 * 4),
             # Can specify string lengths right away.
             ("c", 16),
         ]
@@ -181,15 +181,15 @@ class test_multiply():
 def test_nested_asdict():
     class I1(Structure):
         _fields_ = [
-            ("a", int8),
-            ("b", uint8),
-            ("c", int16),
+            ("a", Int8),
+            ("b", UInt8),
+            ("c", Int16),
         ]
 
     class I2(Structure):
         _fields_ = [
             ("i1", I1),
-            ("a", uint32),
+            ("a", UInt32),
         ]
 
     assert I2.sizeof() == 8


### PR DESCRIPTION
This PR adds IntTypes with **fixed-precision arithmetic and logical operations**. IntTypes are derived from `long` type and they should be fully compatible with other numeric types.

```python
res = u32(0x8080FFFF) << 16 | 0xFFFF
> 0xFFFFFFFF
res = Int32(res)
> -1
```

Type coercion between native and fixed ints depends on LHS type (reverse operators are not overriden):
```python
UInt32 = UInt32 + int
int = int + UInt32
```

IntTypes can be multiplied like ctypes classes for unpacking tuple of values:
```python
(BYTE * 3).unpack('\x01\x02\x03") -> (1, 2, 3)
```

Keep in mind that PR breaks previous behavior, where `uint8` was switching between `str` and `int` representations and returned tuple in case there were more data to unpack. In my opinion that behavior breaks the rule of least astonishment, because on first sight it's hard to recognize what we should expect from `uint8` method call. 

IntType constructor behaves more like casting value to specific IntType. If we want to perform pack/unpack, we should use `p8/16/32/64` for packing or `u8/16/32/64` for unpacking (like in [pwnlib](http://docs.pwntools.com/en/stable/util/packing.html))
For compatibility reasons - I kept `uint8/16/32/64` as alias for `u8/16/32/64`.