### PR TITLE
Add chunks and utf16z

### DIFF
--- a/roach/__init__.py
+++ b/roach/__init__.py
@@ -9,7 +9,7 @@ from roach.disasm import disasm
 from roach.hash.crc import crc32
 from roach.hash.sha import md5, sha1, sha224, sha384, sha256, sha512
 from roach.string.inet import ipv4
-from roach.string.ops import asciiz, hex, unhex, uleb128
+from roach.string.ops import asciiz, utf16z, chunks, hex, unhex, uleb128
 from roach.structure import Structure
 
 from roach.pe import pe2procmem

--- a/roach/procmem.py
+++ b/roach/procmem.py
@@ -14,6 +14,7 @@ except ImportError:
     HAVE_LIEF = False
 
 from roach.disasm import disasm
+from roach.string.ops import chunks, utf16z
 from roach.string.bin import uint8, uint16, uint32, uint64
 
 PAGE_READONLY = 0x00000002
@@ -211,6 +212,24 @@ class ProcessMemory(object):
     def asciiz(self, addr):
         """Read a nul-terminated ASCII string at address."""
         return self.read_until(addr, "\x00")
+
+    def utf16z(self, addr):
+        """Read a nul-terminated UTF-16 string at address."""
+        ret = []
+        while True:
+            r = self.addr_range(addr)
+            if not r:
+                break
+            a, l = r
+            l = a + l - addr
+            buf = self.read(self.v2p(addr), l)
+
+            utf16 = utf16z(buf)
+            ret.append(utf16)
+            if utf16 != buf:
+                break
+            addr = addr + l
+        return "".join(ret)
 
     def regexp(self, query, offset=0, length=0):
         """Performs a regex on the file, must use mmap(2) loading."""

--- a/roach/string/ops.py
+++ b/roach/string/ops.py
@@ -8,6 +8,21 @@ import binascii
 def asciiz(s):
     return s.split("\x00")[0]
 
+def chunks_iter(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+def chunks(l, n):
+    """Return list of successive n-sized chunks from l."""
+    return list(chunks_iter(l, n))
+
+def utf16z(s):
+    chunked = chunks(s, 2)
+    if '\x00\x00' in chunked:
+        return s[:chunked.index('\x00\x00')*2]
+    return s
+
 def hex(s):
     return binascii.hexlify(s)
 

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -4,11 +4,18 @@
 
 from roach import (
     int8, uint8, int16, uint16, int32, uint32, int64, uint64, bigint,
-    asciiz, pad, unpad, ipv4, pack, unpack, hex, unhex, base64, uleb128
+    asciiz, pad, unpad, ipv4, pack, unpack, hex, unhex, base64, uleb128,
+    chunks, utf16z
 )
 
 def test_asciiz():
     assert asciiz("hello\x00world") == "hello"
+
+def test_chunks():
+    assert chunks("hello world", 3) == ["hel", "lo ", "wor", "ld"]
+
+def test_utf16z():
+    assert utf16z("h\x00e\x00l\x00l\x00o\x00\x00\x00world") == "h\x00e\x00l\x00l\x00o\x00"
 
 def test_hex():
     assert hex("hello") == "68656c6c6f"


### PR DESCRIPTION
In this PR, added:
* New `roach.string.ops` method `chunks` splitting buffer into n-sized chunks
* `utf16z` method in procmem (`asciiz` for wide strings)